### PR TITLE
Fix blurry images on Firefox

### DIFF
--- a/client/src/main.css
+++ b/client/src/main.css
@@ -7,5 +7,7 @@
 .img-icon {
     @apply w-16 h-16;
     image-rendering: pixelated;
+    /* Firefox support for pixelated image upscaling */
+    image-rendering: crisp-edges;
     filter: drop-shadow(3px 3px 2px rgba(0, 0, 0, 0.2));
 }


### PR DESCRIPTION
When you view the website on Firefox, it currently looks like this:
![image](https://user-images.githubusercontent.com/31071265/103427496-644b6000-4b8f-11eb-9e92-a69d9275057d.png)
This is due to a CSS property that you used not being supported on Firefox. With my changes it should look like this:
![image](https://user-images.githubusercontent.com/31071265/103427508-77f6c680-4b8f-11eb-86c5-88b9aeafc295.png)

The duplicate CSS property is probably not the best way to do it but it does now work on Firefox and Chrome.