### PR TITLE
Fix "Starting in -3 days" messages

### DIFF
--- a/client/src/components/EventCard.vue
+++ b/client/src/components/EventCard.vue
@@ -84,7 +84,8 @@ export default defineComponent({
                           2
                       )}`;
                 let day;
-                const dayDiff = eventDate.value.getDay() - now.getDay();
+                let dayDiff = eventDate.value.getDay() - now.getDay();
+                if (dayDiff < 0) dayDiff += 7;
                 switch (dayDiff) {
                     case 0:
                         day = 'at';


### PR DESCRIPTION
Currently some event cards are displayed like this:
![image](https://user-images.githubusercontent.com/31071265/103431453-01ad9080-4b9e-11eb-9f4b-9e9cf3c6723d.png)
This is because the current day and the day of the Jacob event are on different IRL weeks and the days are compared like this:
```javascript
const dayDiff = eventDate.value.getDay() - now.getDay();
```
and `getDay()` returns the day of the current week.

If we add `7` to `dayDiff` when it's less than zero, the issue is fixed and we get the expected value.
![image](https://user-images.githubusercontent.com/31071265/103431515-00c92e80-4b9f-11eb-9ee8-e0b3b5143f27.png)
